### PR TITLE
Update for new Bioconductor release

### DIFF
--- a/R/create_slide.R
+++ b/R/create_slide.R
@@ -71,8 +71,25 @@ createSlide <- function(count_mat, slide_info, gene_cutoff=0.1, verbose=TRUE){
     if(!identical(sort(colnames(count_mat)),
                  sort(slide_info$slide$barcode)
                  )){
-        stop("Barcodes in count matrix do not match ",
+        warning("Barcodes in count matrix do not match ",
              "barcodes in slide information.")
+        
+        # https://github.com/zijianni/SpotClean/issues/15
+        # filter out barcodes in count matrix but not in slide info
+        unique_mat_bc = !colnames(count_mat)%in%slide_info$slide$barcode
+        warning("Remove ", sum(unique_mat_bc), " barcodes from count matrix.")
+        count_mat = count_mat[,!unique_mat_bc]
+        
+        # filter out barcodes in slide info but not in count matrix
+        unique_slide_bc = !slide_info$slide$barcode%in%colnames(count_mat)
+        warning("Remove ", sum(unique_slide_bc), 
+                " barcodes from slide information.")
+        slide_info$slide = slide_info$slide[!unique_slide_bc,]
+        
+        if(ncol(count_mat)==0){
+            stop("No barcode in count matrix matches slide information.")
+        }
+        
     }
 
     # rearrange barcodes

--- a/R/decontamination.R
+++ b/R/decontamination.R
@@ -264,7 +264,7 @@ spotclean.SpatialExperiment <- function(slide_obj, gene_keep=NULL,
 
     # Euclidean distance matrix for spots
     slide_distance <- .calculate_euclidean_weight(
-        select(slide, .data$imagerow, .data$imagecol)
+        select(slide, "imagerow", "imagecol")
     )
     rownames(slide_distance) <- colnames(slide_distance) <- slide$barcode
 

--- a/R/decontamination.R
+++ b/R/decontamination.R
@@ -288,7 +288,6 @@ spotclean.SpatialExperiment <- function(slide_obj, gene_keep=NULL,
     spot_distance <- abs(coef(lm_tmp)[2])
 
     # Keep highly expressed and highly variable genes
-    mean_exp <- rowSums(raw_data)/length(ts_idx)
     if(is.null(gene_keep)){
         gene_keep <- keepHighGene(raw_ts_data, verbose=verbose)
 

--- a/tests/testthat/test-convert_to_seurat.R
+++ b/tests/testthat/test-convert_to_seurat.R
@@ -39,6 +39,8 @@ seurat_obj_f <- convertToSeurat(mbrain_obj,image_dir = spatial_dir,
 
 test_that("Filter background spots",{
     expect_equal(dim(seurat_obj_f), c(100, 2702))
-    expect_identical(colnames(seurat_obj_f),
-            mbrain_slide_info$slide$barcode[mbrain_slide_info$slide$tissue==1])
+    expect_identical(
+        colnames(seurat_obj_f),
+        sort(mbrain_slide_info$slide$barcode[mbrain_slide_info$slide$tissue==1])
+        )
 })

--- a/tests/testthat/test-create_slide.R
+++ b/tests/testthat/test-create_slide.R
@@ -12,7 +12,7 @@ mbrain_slide_info <- read10xSlide(
 
 
 test_that("Barcodes not matching", {
-    expect_error(createSlide(mbrain_raw[,1:10], mbrain_slide_info),
+    expect_warning(createSlide(mbrain_raw[,1:10], mbrain_slide_info),
                  "Barcodes in count matrix do not match")
 })
 

--- a/tests/testthat/test-decontamination.R
+++ b/tests/testthat/test-decontamination.R
@@ -16,8 +16,8 @@ mbrain_obj <- createSlide(mbrain_raw,
 # test output
 
 test_that("Decontamination",{
-    expect_silent(mbrain_decont_obj <- spotclean(mbrain_obj, candidate_radius=20,
-                                                 maxit = 3, verbose = FALSE))
+    expect_no_error(mbrain_decont_obj <- spotclean(
+        mbrain_obj, candidate_radius=20, maxit = 3, verbose = FALSE))
     expect_s4_class(mbrain_decont_obj,"SummarizedExperiment")
     expect_identical(names(mbrain_decont_obj@assays),"decont")
     expect_equal(metadata(mbrain_decont_obj)$ARC_score, 0.05160659)


### PR DESCRIPTION
- Update unittest due to Seurat updates and other dependency updates.
- Allow expression matrix to contain a subset of barcodes in slide info. Barcodes in slide info but not in expression matrix will be filtered out before processing. Update unittest to capture this feature.